### PR TITLE
[FIX] Overloading child_ids

### DIFF
--- a/base_crapo_workflow/models/crapo_action.py
+++ b/base_crapo_workflow/models/crapo_action.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 
-from odoo import models, api
+from odoo import models, api, fields
 from odoo.addons.queue_job.job import job
 
 
@@ -15,6 +15,9 @@ class CrapoAction(models.Model):
     _name = "crapo.action"
     _inherit = "ir.actions.server"
     _description = u"A specialization of server actions for Crapo"
+
+    # Multi
+    child_ids = fields.Many2many("crapo.action", "rel_crapo_actions")
 
     @api.model
     def _get_states(self):


### PR DESCRIPTION
Overloading child_ids to change comodel from ir.actions.server to crapo.action and change relation name. If we don't do that, there is an issue when child_ids is write because of the methode BaseModel._check_m2m_recursion who faile.